### PR TITLE
Added cut tag feature for posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,6 @@ class Post < ActiveRecord::Base
   include Models::Indestructible
   
   CUT = /<cut(\stext\s?=\s?\\?[\",']([^[\",',\\]]*)\\?[\",']\s?)?>/
-  DEFAULT_CUT = 'More under the cut'
   
   default_scope order: 'posts.id desc'
   
@@ -88,7 +87,7 @@ class Post < ActiveRecord::Base
   
   def cut_tag
     if content_parts.size > 1
-      content.match(CUT).to_a[2] || DEFAULT_CUT
+      content.match(CUT).to_a[2] || I18n.translate(:default_cut)
     end
   end
 protected

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,9 @@ class Post < ActiveRecord::Base
   include Models::Mentionable
   include Models::Indestructible
   
+  CUT = /<cut(\stext\s?=\s?\\?[\",']([^[\",',\\]]*)\\?[\",']\s?)?>/
+  DEFAULT_CUT = 'More under the cut'
+  
   default_scope order: 'posts.id desc'
   
   belongs_to :user, inverse_of: :posts
@@ -12,7 +15,6 @@ class Post < ActiveRecord::Base
   has_many :likes
   
   validates :user, :title, presence: true
-  validates :cuts_count, inclusion: { in: [0, 1] }
   validates :preview, length: { minimum: 3, maximum: 500, too_long: 'is too long. Use <cut> tag to separate preview and text.', too_short: 'is too short.' }
   validates :tags_size, numericality: { greater_than: 0 }
   validates :status, format: { with: %r{http://goo.gl/xxxxxx} }, 
@@ -58,7 +60,7 @@ class Post < ActiveRecord::Base
   end
   
   def body
-    content.to_s.gsub('<cut>', "\r\n")
+    content.sub(CUT, "\r\n")
   end
   
   def tags_size
@@ -84,28 +86,27 @@ class Post < ActiveRecord::Base
     where("title like :q or content like :q", q: "%#{text}%")
   end
   
+  def cut_tag
+    if content_parts.size > 1
+      content.match(CUT).to_a[2] || DEFAULT_CUT
+    end
+  end
 protected
   
   def cache_preview
-    write_attribute(:preview_cache, Markdown.markdown(begin
-      raw = Replaceable.new(preview)
+    preview = Markdown.markdown(begin
+      raw = Replaceable.new(self.preview)
       raw.replace_gists!.replace_tags!.replace_usernames!
       raw.to_s
-    end))
-  end
-  
-  def cuts_count
-    if content.blank?
-      0
-    elsif content == '<cut>'
-      1
-    else
-      content.split('<cut>').size - 1
-    end
+    end)
+    
+    preview << %(<a href="/posts/#{id}">#{cut_tag}</a>).html_safe if cut_tag
+    write_attribute(:preview_cache, preview)
   end
   
   def content_parts
-    @content_parts ||= content.to_s.split('<cut>', 2)
+    m = content.split(CUT, 2)
+    @content_parts ||= [m.first, m.last].uniq.compact
   end
   
   def tweet

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -85,7 +85,7 @@ class Post < ActiveRecord::Base
     where("title like :q or content like :q", q: "%#{text}%")
   end
   
-  def cut_tag
+  def cut_text
     if content_parts.size > 1
       content.match(CUT).to_a[2] || I18n.translate(:default_cut)
     end
@@ -99,7 +99,7 @@ protected
       raw.to_s
     end)
     
-    preview << %(<a href="/posts/#{id}">#{cut_tag}</a>).html_safe if cut_tag
+    preview << %(<a href="/posts/#{id}">#{cut_text}</a>).html_safe if cut_text
     write_attribute(:preview_cache, preview)
   end
   

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -87,7 +87,7 @@ class Post < ActiveRecord::Base
   
   def cut_text
     if content_parts.size > 1
-      content.match(CUT).to_a[2] || I18n.translate(:default_cut)
+      content[CUT, 2] || I18n.translate(:default_cut)
     end
   end
 protected

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -7,7 +7,7 @@
   fieldset
     = f.text_field :title, :placeholder => 'Title'
   fieldset
-    = f.text_area :content, :size => '40x12', :placeholder => "Preview<cut>Body", :class => 'hint', :id => 'post_content'
+    = f.text_area :content, :size => '40x12', :placeholder => "Preview<cut text=\"More under the cut\">Body", :class => 'hint', :id => 'post_content'
   fieldset
     = f.check_box :question
     = f.label :question, 'Question?'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,5 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: "Hello world"
+  default_cut: 'More under the cut'
+    

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -37,10 +37,69 @@ describe Post do
     end
   end
   
+  describe '#cut_tag' do
+    context 'with text' do
+      subject { create(:post, content: 'preview<cut text="More">body #ruby') }
+      
+      its(:cut_tag) do
+        should == 'More'
+      end
+    end
+    
+    context 'without text' do
+      subject { create(:post, content: 'preview<cut>body #ruby') }
+      
+      its(:cut_tag) do
+        should == Post::DEFAULT_CUT
+      end
+    end
+  end
+  
   describe '#title_for_notification' do
     let(:post) { create :post }
     
     it { post.title_for_notification(true).should == post.title }
     it { post.title_for_notification(false).should == post.id }
+  end
+  
+  describe 'preview and body for post' do
+    context 'with single cut tag' do
+      context 'with text' do
+        let(:post) { create(:post, content: 'preview<cut text="More">body #ruby') }
+
+        it 'should separate preview from body' do
+          post.preview.should == 'preview'
+          post.body.should == "preview\r\nbody #ruby"
+        end
+      end
+
+      context 'without text' do
+        let(:post) { create(:post, content: 'preview<cut>body #ruby') }
+
+        it 'should separate preview from body' do
+          post.preview.should == 'preview'
+          post.body.should == "preview\r\nbody #ruby"
+        end
+      end
+    end
+    
+    context 'with more than one cut tag' do
+      context 'with text' do
+        let(:post) { create(:post, content: 'preview<cut text="More">body #ruby w<cut text="More"> other text') }
+
+        it 'should return array of two elements' do
+          post.send(:content_parts).should == ['preview', 'body #ruby w<cut text="More"> other text']
+        end
+      end
+      
+      context 'without text' do
+        let(:post) { create(:post, content: 'preview<cut>body #ruby <cut> #haskell') }
+
+        it 'should separate preview from body' do
+          post.preview.should == 'preview'
+          post.body.should == "preview\r\nbody #ruby <cut> #haskell"
+        end
+      end
+    end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -50,7 +50,7 @@ describe Post do
       subject { create(:post, content: 'preview<cut>body #ruby') }
       
       its(:cut_tag) do
-        should == Post::DEFAULT_CUT
+        should == I18n.translate(:default_cut)
       end
     end
   end
@@ -62,7 +62,7 @@ describe Post do
     it { post.title_for_notification(false).should == post.id }
   end
   
-  describe 'preview and body for post' do
+  describe 'preview and body' do
     context 'with single cut tag' do
       context 'with text' do
         let(:post) { create(:post, content: 'preview<cut text="More">body #ruby') }

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -37,11 +37,11 @@ describe Post do
     end
   end
   
-  describe '#cut_tag' do
+  describe '#cut_text' do
     context 'with text' do
       subject { create(:post, content: 'preview<cut text="More">body #ruby') }
       
-      its(:cut_tag) do
+      its(:cut_text) do
         should == 'More'
       end
     end
@@ -49,7 +49,7 @@ describe Post do
     context 'without text' do
       subject { create(:post, content: 'preview<cut>body #ruby') }
       
-      its(:cut_tag) do
+      its(:cut_text) do
         should == I18n.translate(:default_cut)
       end
     end


### PR DESCRIPTION
Cut tag without text will be replaced with default link, so we don't need to run
any migrations to fix old posts.
