### PR TITLE
Add hint about post tags

### DIFF
--- a/app/assets/stylesheets/articles/posts.css.scss
+++ b/app/assets/stylesheets/articles/posts.css.scss
@@ -133,3 +133,8 @@ article.post {
   background: transparent url('private_lock.png') scroll no-repeat left center;
   padding-left: 20px;
 }
+
+.hint {
+  font-style: italic;
+  color: #aaa;
+}

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -7,6 +7,7 @@
     = f.text_field :title, :placeholder => 'Title'
   fieldset
     = f.text_area :content, :size => '40x12', :placeholder => "Preview<cut text=\"More under the cut\">Body", :class => 'hint raw', :id => 'post_content'
+    .hint You can add tags (at least one is needed) by mentioning in post's body: #gistflow #code #ruby
   div class="preview markdown"
   fieldset
     = f.check_box :question
@@ -16,7 +17,7 @@
     = f.label :is_private, 'Private'
   div class="actions group"
     div class="left"
-      | This text will be parsed by 
+      | This text will be parsed by
       = link_to 'Markdown', 'http://daringfireball.net/projects/markdown/syntax', :class => 'highlight'
       | . See 
       = link_to 'hints', '#', :class => 'hints'


### PR DESCRIPTION
I was confused with a failed tag validation, when I tried to submit my first post. 
- Add hint itself to a posts/form partial
- Add reusable .hint class
