### PR TITLE
Add preview for comment notification emails

### DIFF
--- a/app/models/notification/comment.rb
+++ b/app/models/notification/comment.rb
@@ -1,6 +1,6 @@
 class Notification::Comment < Notification
   include ActionView::Helpers::UrlHelper
-  
+
   def title
     "#{notifiable.user} commented on post #{notifiable.post.title}"
   end
@@ -8,19 +8,23 @@ class Notification::Comment < Notification
   def mailer_title
     "New comment on post #{notifiable.post.title}"
   end
-  
+
   def target_url
     "#{host}/posts/#{notifiable.post.id}"
   end
-  
+
   def message post_title = false
     user, post, comment = notifiable.user, notifiable.post, notifiable
     link_to_user = %{<a href="#{host}/users/#{user.username}">#{user}</a>}
-    
+
     title = post.title_for_notification post_title
     link_to_post = %{<a href="#{host}/posts/#{post.id}#comment-#{comment.id}" data-title="#{post.title}" class="notification_link">#{title}</a>}
     "#{link_to_user} wrote a comment in #{link_to_post}".html_safe
   rescue
     "Comment was deleted"
+  end
+
+  def preview
+    notifiable.body
   end
 end

--- a/app/views/user_mailer/notification_email.html.slim
+++ b/app/views/user_mailer/notification_email.html.slim
@@ -2,7 +2,7 @@ doctype
 html
   head
   body
-    p New notification!
+    p New notification
     p = @notification.message(true)
     p style="border-left: 3px solid #999; padding-left: 10px;" = @notification.preview
     p

--- a/app/views/user_mailer/notification_email.html.slim
+++ b/app/views/user_mailer/notification_email.html.slim
@@ -2,9 +2,10 @@ doctype
 html
   head
   body
-    p New notification
+    p New notification!
     p = @notification.message(true)
-    p 
+    p style="border-left: 3px solid #999; padding-left: 10px;" = @notification.preview
+    p
       | See all notifications at 
       = link_to 'your account', 'http://gistflow.com/account/notifications'
       | .


### PR DESCRIPTION
Add preview to message like in new post notification.
![gistflow-notification](https://f.cloud.github.com/assets/869453/15127/ee0acd80-46fc-11e2-8a69-d0b8b6b293cc.png)
